### PR TITLE
Fix broken build.

### DIFF
--- a/Formula/odo.rb
+++ b/Formula/odo.rb
@@ -14,10 +14,11 @@ class Odo < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    (buildpath/"src/github.com/redhat-developer").mkpath
-    ln_s buildpath, buildpath/"src/github.com/redhat-developer/odo"
-    system "make", "bin"
-    bin.install "odo"
+    (buildpath/"src/github.com/redhat-developer/odo").install buildpath.children
+    cd buildpath/"src/github.com/redhat-developer/odo" do
+      system "make", "bin"
+      bin.install "odo"
+    end
   end
 
   test do


### PR DESCRIPTION
This used to do a symlink from buildpath to gopath/src/....
Symplinks can be problematic. Now source is extracted directly to
gopath, no need for symlink.